### PR TITLE
Fix for collision of coincident circle bodies in Simulator.hpp.

### DIFF
--- a/include/Simulator.hpp
+++ b/include/Simulator.hpp
@@ -157,17 +157,19 @@ class Simulator
                 double dist = t1.p.dist(t2.p);
                 double overlap = (b1.r + b2.r) - dist;
 
-                if (dist == 0) {
-                    // Circles are coincident.  If unchecked, this leads to division by zero below.  
-                    // Arbitrarily perturb body 1 by plus-or-minus 1 in x and y. 
-                    t1.p.x += 1 - (rand() % 3);
-                    t1.p.y += 1 - (rand() % 3);
-                    continue;
-                }
-
                 // circles overlap if the overlap is positive
                 if (overlap > m_overlapThreshold)
                 {
+                    if (dist == 0)
+                    {
+                        // Circles are coincident.  If unchecked, this leads to
+                        // division by zero below.  Arbitrarily perturb body 1
+                        // by plus-or-minus 1 in x and y. 
+                        t1.p.x += 1 - (rand() % 3);
+                        t1.p.y += 1 - (rand() % 3);
+                        continue;
+                    }
+
                     // record that a collision took place between these two objects
                     m_collisions.push_back({ &t1, &t2, &b1, &b2 });
 

--- a/include/Simulator.hpp
+++ b/include/Simulator.hpp
@@ -157,6 +157,14 @@ class Simulator
                 double dist = t1.p.dist(t2.p);
                 double overlap = (b1.r + b2.r) - dist;
 
+                if (dist == 0) {
+                    // Circles are coincident.  If unchecked, this leads to division by zero below.  
+                    // Arbitrarily perturb body 1 by plus-or-minus 1 in x and y. 
+                    t1.p.x += 1 - (rand() % 3);
+                    t1.p.y += 1 - (rand() % 3);
+                    continue;
+                }
+
                 // circles overlap if the overlap is positive
                 if (overlap > m_overlapThreshold)
                 {


### PR DESCRIPTION
Without this fix if circle bodies happen to be created (or become) coincident then there is a division by zero and the bodys' positions become NaNs.  The fix is just to randomly shift the position of one body by a small random amount.  